### PR TITLE
fix(ci): Use iotaledger fork of actions-gh-pages

### DIFF
--- a/.github/workflows/deploy_to_gh-pages.yml
+++ b/.github/workflows/deploy_to_gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - run: mdbook build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
Use `iotaledger` fork of actions-gh-pages since it uses a GitHub token﻿
