### PR TITLE
Changed Hornet url to Docs

### DIFF
--- a/docs/node-software/node-software.md
+++ b/docs/node-software/node-software.md
@@ -14,7 +14,7 @@ At this stage, we recommend using Hornet since it has several optional features 
 
 ## Node software
 
-- [hornet (branch: develop)](https://github.com/gohornet/hornet/tree/develop)
+- [hornet](https://hornet.docs.iota.org)
 - [bee (branch: chrysalis-pt-2)](https://github.com/iotaledger/bee/tree/chrysalis-pt-2)
 
 ## Node API specification


### PR DESCRIPTION
Initial version of Docs for Hornet 0.6.0 is out. So changing url to the new domain with Docs