### PR TITLE
DOCS - use absolute image paths

### DIFF
--- a/docs/guides/dev_guide.md
+++ b/docs/guides/dev_guide.md
@@ -95,7 +95,7 @@ Having many different accounts may have a negative impact on performance while [
 
 :::
 
-![address_generation](../../static/img/guides/address_generation.svg)
+![address_generation](/img/guides/address_generation.svg)
 
 So in case of Chrysalis, the derivation path of address/key space is `[seed]/44/4218/{int}/{0,1}/{int}`:
 * The levels `purpose` and `coin_type` are given.
@@ -126,7 +126,7 @@ For further refefence, please see our: [Protocol-rfc#0018 - Transaction Payload]
 
 Needless to say, the IOTA network ensures the outer structure of the message itself is valid and strictly complies with network consensus protocol. However, the inner structure is very flexible, future-proof, and offers an unmatched network extensibility.
 
-![messages_in_tangle](../../static/img/guides/messages_in_tangle.svg)
+![messages_in_tangle](/img/guides/messages_in_tangle.svg)
 
 The current Chrysalis network incorporates the following core payloads:
 * `SignedTransaction`: a payload that describes `UTXO` transactions that are the cornerstones of value-based transfers in the IOTA network. Via this payload, a `message` can be also cryptographically signed.
@@ -152,7 +152,7 @@ Below is a simplified analogy of how the UTXO works:
   *  `Output D` = 50 tokens.
 * The total supply remains the same, just number of outputs differs and some outputs were replaced by other outputs in the process.
 
-![utxo](../../static/img/guides/utxo.svg)
+![utxo](/img/guides/utxo.svg)
 
 The key takeaway of the outlined process above is the fact that each unique `output` can be spent **only once**. Once the given `output` is spent, it cannot be used any more and is irrelevant in regards to the ledger state.
 

--- a/docs/guides/exchange_guide.md
+++ b/docs/guides/exchange_guide.md
@@ -7,7 +7,7 @@
 IOTA is built on an architecture that was designed to be the backbone of the Internet of Things (IoT) environment of the future. But this architecture has made it more challenging for service providers like exchanges to integrate IOTA compared to traditional blockchain-based distributed ledgers.
 
 Within the Chrysalis update (also known as IOTA 1.5), some building blocks were changed to be more approachable and more aligned with currently leveraged standards. We also ship many [client libraries](../libraries/overview.md) to help developers implement IOTA into their applications:
-![layers](../../static/img/guides/wallet_rs_layers.svg)
+![layers](/img/guides/wallet_rs_layers.svg)
 
 ## How Do I Implement It to My Exchange?
 
@@ -24,7 +24,7 @@ The library also allows consumers to assign a meaningful alias to each account. 
 
 It also leaves the choice to users if they want to segregate their funds across multiple accounts or multiple addresses. The following illustration outlines the relationships between seed, accounts, and addresses: 
 
-![accounts](../../static/img/guides/accounts.svg)
+![accounts](/img/guides/accounts.svg)
 
 ### Multi Account Approach
 

--- a/docs/introduction/path_to_chrysalis.md
+++ b/docs/introduction/path_to_chrysalis.md
@@ -17,7 +17,7 @@ The intended outcomes for Chrysalis were:
 
 ## The Stages to Chrysalis
 
-![](../../static/img/introduction/path_to_chrysalis/01.png)
+![](/img/introduction/path_to_chrysalis/01.png)
 
 The Chrysalis upgrade was a complex undertaking. We coordinated a number of distinct products to ensure a smooth transition for IOTA’s current users and partners. In addition to the core node software, we also needed to update our wallet software, our libraries, and the entire infrastructure.  
 

--- a/docs/introduction/what_is_chrysalis.md
+++ b/docs/introduction/what_is_chrysalis.md
@@ -2,11 +2,11 @@
 
 The objective of the IOTA Foundation was to optimize the IOTA mainnet before Coordicide and to offer an enterprise-ready solution for our ecosystem. This was achieved by an intermediate update called `Chrysalis`. You can read more about how Chrysalis was strategically released here.
 
-![](../../static/img/introduction/what_is_chrysalis/00.gif)
+![](/img/introduction/what_is_chrysalis/00.gif)
 
 A chrysalis is “the form a caterpillar takes before it emerges from its cocoon as a fully-formed moth or butterfly”. In the context of IOTA, Chrysalis was the mainnet’s intermediate stage before Coordicide's completion. The main purpose of Chrysalis is to improve the usability of the previous IOTA mainnet, for users and developers alike.
 
-![](../../static/img/introduction/02_path_to.png)
+![](/img/introduction/02_path_to.png)
 
 Why is this process of adopting major protocol improvements relatively unique to IOTA among permissionless Digital Ledger Technologies (DLTs)? The simple answer is the absence of miners. In most permissionless DLTs, the miners’ economic incentives differ from those of regular network users. Changes to throughput and network latencies can disrupt the fee market the miners rely on. This in turn makes them likely to object to network upgrades as it affects their bottom line.
 
@@ -15,31 +15,31 @@ In IOTA, validators and users are one and the same. There is no conflict of inte
 ## What Are the Specific Chrysalis Upgrades?
 
 ### White-flag Approach
-![](../../static/img/introduction/what_is_chrysalis/01.png)
+![](/img/introduction/what_is_chrysalis/01.png)
 [The White-flag approach](https://iota.cafe/t/conflict-white-flag-mitigate-conflict-spamming-by-ignoring-conflicts/233), which is used for calculating balances. It is a simpler, conflict-ignoring approach that improved the speed and efficiency of tip selection, eliminated many network attacks, and significantly reduced the need for reattachments.
 
 ### New Milestone Selection Algorithm
-![](../../static/img/introduction/what_is_chrysalis/02.png)
+![](/img/introduction/what_is_chrysalis/02.png)
 [A new milestone selection algorithm for the Coordinator](https://iota.cafe/t/coordinator-improvements/310) that focuses on allowing the network to support many more confirmed transactions per second (CTPS) than before, with higher computational efficiency.
 
 ### URTS Tip Selection
-![](../../static/img/introduction/what_is_chrysalis/03.png)
+![](/img/introduction/what_is_chrysalis/03.png)
 A new [Uniform Random Tip Selection](https://github.com/iotaledger/protocol-rfcs/blob/master/text/0008-uniform-random-tip-selection/0008-uniform-random-tip-selection.md) in node software. It is significantly faster and more efficient than the previous tip selection algorithm.
 
 ### Ed25519 Signature Scheme
-![](../../static/img/introduction/what_is_chrysalis/04.png)
+![](/img/introduction/what_is_chrysalis/04.png)
 [The Ed25519 signature scheme](https://github.com/iotaledger/protocol-rfcs/blob/ee07797acb5940b7dbb5c3411b184ccdc6afdbb1/text/0000-ed25519-signature-scheme/0000-ed25519-signature-scheme.md) has been added to the network, replacing the current Winternitz one time signature scheme (W-OTS) signature scheme. Using an EdDSA signature scheme allows the protocol and clients using the protocol to run more efficiently on established hardware. Unlike W-OTS, the Ed25519 signature scheme also allows for the re-use of private keys, and, with that, introduces reusable addresses to the protocol. This change also dramatically reduces the transaction size, saving network bandwidth and processing time.
 
 ### Atomic Transactions
-![](../../static/img/introduction/what_is_chrysalis/05.png)
+![](/img/introduction/what_is_chrysalis/05.png)
 [Atomic transactions](https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md) that move the protocol from the current, complicated, bundle construct and use simpler atomic transactions instead. This results in much simpler development, and more adaptable and maintainable code of the core software. In addition, atomic transactions reduce network overhead, reduce transaction validation and signature verification load, and improve spam protection and congestion control.
 
 ### Switch to UTXO Model
-![](../../static/img/introduction/what_is_chrysalis/06.png)
+![](/img/introduction/what_is_chrysalis/06.png)
 [Switch to the UTXO model](https://iota.cafe/t/switching-to-utxo-model-for-balances-colored-coins-easier-conflict-resolution/229) from the current account model. Every coin on an address becomes uniquely identifiable and every spend names the exact coins that it wants to move. This allows for faster and more exact conflict handling and improves resilience and security of the protocol. In addition, switching to UTXO makes other functionalities, such as colored tokens, on the protocol possible in the future.
 
 ### Internal Binary Representation
-![](../../static/img/introduction/what_is_chrysalis/07.png)
+![](/img/introduction/what_is_chrysalis/07.png)
 [A switch to an internal binary representation of the trinary transaction](https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md). This allows us to work on binary data for validation, IO, and other processing, without the current reliance on binary-ternary conversions as in the pre-Chrysalis node software. The switch to binary transactions further reduces transaction size, saving network bandwidth and processing time.
 
 ### New Node API and Client Libraries

--- a/docs/libraries/overview.md
+++ b/docs/libraries/overview.md
@@ -19,7 +19,7 @@ The official IOTA libraries serve as `one-source-code-of-truth` to IOTA users an
 <iframe src="https://www.youtube.com/embed/N2VW3zJQmso" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-![overview-libs](../../static/img/guides/overview-libraries.svg)
+![overview-libs](/img/guides/overview-libraries.svg)
 
 All libraries are in active development. The libraries target the Chrysalis testnet and no longer work with the previous IOTA mainnet.
 

--- a/docs/testnet.md
+++ b/docs/testnet.md
@@ -4,8 +4,8 @@
 
 The IOTA Foundation provides the following load-balanced public testnet endpoint:
 
-- [https://lb-0.h.chrysalis-devnet.iota.cafe](https://lb-0.h.chrysalis-devnet.iota.cafe)
-- [https://lb-1.h.chrysalis-devnet.iota.cafe/](https://lb-1.h.chrysalis-devnet.iota.cafe/)
+- [https://api.lb-0.h.chrysalis-devnet.iota.cafe/](https://api.lb-0.h.chrysalis-devnet.iota.cafe/)
+- [https://api.lb-1.h.chrysalis-devnet.iota.cafe/](https://api.lb-1.h.chrysalis-devnet.iota.cafe/)
 
 ## Developer tools
 

--- a/docs/testnet.md
+++ b/docs/testnet.md
@@ -1,27 +1,14 @@
 # Testnet
 
 ## Public Infrastructure
-The IOTA Foundation provides the following loadbalanced public testnet endpoint:
 
-- api.lb-0.testnet.chrysalis2.com
+The IOTA Foundation provides the following load-balanced public testnet endpoint:
 
-:::info
-
-We recommend using the load balancer for most scenarios.
-
-:::
-
-Single node endpoints that expose native MQTT, in case you need them, are:
-
-- api.hornet-0.testnet.chrysalis2.com.
-- api.hornet-1.testnet.chrysalis2.com.
-- api.hornet-2.testnet.chrysalis2.com.
-- api.hornet-3.testnet.chrysalis2.com.
-
-These endpoints have MQTT (via WebSockets and raw TCP) exposed and offer the HTTP REST API (according to this [specification](https://editor.swagger.io/?url=https://raw.githubusercontent.com/rufsam/protocol-rfcs/master/text/0026-rest-api/rest-api.yaml))
-over TLS.
+- [https://lb-0.h.chrysalis-devnet.iota.cafe](https://lb-0.h.chrysalis-devnet.iota.cafe)
+- [https://lb-1.h.chrysalis-devnet.iota.cafe/](https://lb-1.h.chrysalis-devnet.iota.cafe/)
 
 ## Developer tools
+
 - [Explorer](https://explorer.iota.org/testnet)
 - [Online Faucet](https://faucet.testnet.chrysalis2.com/)
 - [cli-wallet](https://github.com/iotaledger/cli-wallet)

--- a/docs/tutorials/one-click-private-tangle.md
+++ b/docs/tutorials/one-click-private-tangle.md
@@ -14,7 +14,7 @@ IOTA [mainnet](../mainnet.md) and [testnet](../testnet.md) are public IOTA Netwo
 
 The figure below depicts a minimum viable deployment architecture of a Private Tangle using [Docker](https://docker.io). 
 
-![Private Tangle Architecture](../../static/img/tutorials/one-click-private-tangle-architecture.png "Private Tangle Architecture")
+![Private Tangle Architecture](/img/tutorials/one-click-private-tangle-architecture.png "Private Tangle Architecture")
 
 There are three main nodes identified: 
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -4,4 +4,4 @@ This page outlines the fundamental changes to the IOTA protocol which were deplo
 
 This is the technical documentation for developers. For updates and network status, please visit [https://chrysalis.iota.org](https://chrysalis.iota.org). 
 
-![](../static/img/introduction/01_butterfly.png)
+![](/img/introduction/01_butterfly.png)


### PR DESCRIPTION
# Description of change

* Updated all docs images to use absolute paths instead of relative so they can be integrated into the upcoming wiki

## Type of change

- [ ] Documentation Fix

## How the change has been tested
Changes were tested on a local docs site. 


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
