### PR TITLE
Rename chrysalis docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 > Everything about Chrysalis for developers.
 
-You can see a rendered version on [https://wiki.iota.org/chrysalis-docs/welcome](https://wiki.iota.org/chrysalis-docs/welcome).
+You can see a rendered version on [./welcome](./welcome).
 
 If you would like to serve the docs locally, please follow [these instructions](DOCUMENATION_README.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 > Everything about Chrysalis for developers.
 
-You can see a rendered version on [./welcome](./welcome).
+You can see a rendered version on [https://wiki.iota.org/introduction/welcome](./welcome).
 
 If you would like to serve the docs locally, please follow [these instructions](DOCUMENATION_README.md)

--- a/docs/guides/developer.md
+++ b/docs/guides/developer.md
@@ -52,7 +52,7 @@ For further reference, please see our [Protocol-rfc#0020 - Bech32 Address Format
 ### Seed
 With the updated [wallet library](../libraries/wallet.md), developers do not need to use a self-generated seed. By default, the seed is created and stored in Stronghold, our in-house built security enclave. It is not possible to extract the seed from Stronghold for security purposes. Stronghold uses encrypted snapshots that can easily be backed up and securely shared between devices. These snapshots are then further secured with a password.
 
-More information about IOTA Wallet Library is available on the [Wallet docs page](https://wiki.iota.org/wallet.rs/welcome) or in the [Exchange guide](https://wiki.iota.org/chrysalis-docs/guides/exchange), which is mainly focuses on value transactions.
+More information about IOTA Wallet Library is available on the [Wallet docs page](https://wiki.iota.org/wallet.rs/welcome) or in the [Exchange guide](./guides/exchange), which is mainly focuses on value transactions.
 
 :::note
 
@@ -104,7 +104,7 @@ And there are a few additional things to note:
 
 :::note 
 
-Having many different accounts may have a negative impact on performance while in the [account discovery](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery) phase. So, if you are after using multiple, different accounts then you may be interested in our stateful library [wallet.rs](https://wiki.iota.org/wallet.rs/welcome) that incorporates all business logic needed to efficiently manage independent accounts. Additionally, our [exchange guide](https://wiki.iota.org/chrysalis-docs/guides/exchange) provides some useful tips on how different accounts may be leveraged.
+Having many different accounts may have a negative impact on performance while in the [account discovery](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery) phase. So, if you are after using multiple, different accounts then you may be interested in our stateful library [wallet.rs](https://wiki.iota.org/wallet.rs/welcome) that incorporates all business logic needed to efficiently manage independent accounts. Additionally, our [exchange guide](./guides/exchange) provides some useful tips on how different accounts may be leveraged.
 
 :::
 

--- a/docs/guides/developer.md
+++ b/docs/guides/developer.md
@@ -52,7 +52,7 @@ For further reference, please see our [Protocol-rfc#0020 - Bech32 Address Format
 ### Seed
 With the updated [wallet library](../libraries/wallet.md), developers do not need to use a self-generated seed. By default, the seed is created and stored in Stronghold, our in-house built security enclave. It is not possible to extract the seed from Stronghold for security purposes. Stronghold uses encrypted snapshots that can easily be backed up and securely shared between devices. These snapshots are then further secured with a password.
 
-More information about IOTA Wallet Library is available on the [Wallet docs page](https://wiki.iota.org/wallet.rs/welcome) or in the [Exchange guide](./guides/exchange), which is mainly focuses on value transactions.
+More information about IOTA Wallet Library is available on the [Wallet docs page](https://wiki.iota.org/wallet.rs/welcome) or in the [Exchange guide](./exchange), which is mainly focuses on value transactions.
 
 :::note
 
@@ -104,7 +104,7 @@ And there are a few additional things to note:
 
 :::note 
 
-Having many different accounts may have a negative impact on performance while in the [account discovery](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery) phase. So, if you are after using multiple, different accounts then you may be interested in our stateful library [wallet.rs](https://wiki.iota.org/wallet.rs/welcome) that incorporates all business logic needed to efficiently manage independent accounts. Additionally, our [exchange guide](./guides/exchange) provides some useful tips on how different accounts may be leveraged.
+Having many different accounts may have a negative impact on performance while in the [account discovery](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery) phase. So, if you are after using multiple, different accounts then you may be interested in our stateful library [wallet.rs](https://wiki.iota.org/wallet.rs/welcome) that incorporates all business logic needed to efficiently manage independent accounts. Additionally, our [exchange guide](./exchange) provides some useful tips on how different accounts may be leveraged.
 
 :::
 

--- a/docs/guides/exchange.md
+++ b/docs/guides/exchange.md
@@ -81,7 +81,7 @@ The following examples cover the *multi-account approach* using the `NodeJS` bin
 
 :::note
 
-If you are looking for other languages, please read the [wallet library overview](https://wiki.iota.org/chrysalis-docs/libraries/wallet).
+If you are looking for other languages, please read the [wallet library overview](./libraries/wallet).
 
 :::
 
@@ -90,7 +90,7 @@ Since all `wallet.rs` bindings are based on core principles provided by the `wal
 ### 1. Set up the Wallet Library
 First, you should install the components that are needed to use `wallet.rs` and the binding of your choice; it may vary a bit from language to language. In the case of the `NodeJs` binding, it is straightforward since it is distributed via the `npm` package manager. We also recommend you use `dotenv` for password management.
 
-You can read more about [backup and security in this guide](https://wiki.iota.org/chrysalis-docs/guides/backup_security).
+You can read more about [backup and security in this guide](./guides/backup_security).
 
 ```bash
 npm install @iota/wallet dotenv
@@ -119,7 +119,7 @@ One of the key principles behind the `stronghold`-based storage is that no one c
 
 :::note
 
-Keep the `stronghold` password and the `stronghold` database on separate devices. See the [backup and security guide](https://wiki.iota.org/chrysalis-docs/guides/backup_security) for more information.
+Keep the `stronghold` password and the `stronghold` database on separate devices. See the [backup and security guide](./guides/backup_security) for more information.
 
 :::
 
@@ -296,4 +296,4 @@ Default options are fine and are successful; however, additional options can be 
 
 The `Account.send()` function returns a `wallet message` that fully describes the given transaction. The `messageId` can be used later for checking a confirmation status. Individual messages related to the given account can be obtained via the `account.listMessages()` function.
 
-Please note that when sending tokens, a [dust protection](https://wiki.iota.org/chrysalis-docs/guides/developer#dust-protection) mechanism should be considered. 
+Please note that when sending tokens, a [dust protection](./guides/developer#dust-protection) mechanism should be considered. 

--- a/docs/guides/exchange.md
+++ b/docs/guides/exchange.md
@@ -81,7 +81,7 @@ The following examples cover the *multi-account approach* using the `NodeJS` bin
 
 :::note
 
-If you are looking for other languages, please read the [wallet library overview](./libraries/wallet).
+If you are looking for other languages, please read the [wallet library overview](../libraries/wallet).
 
 :::
 
@@ -90,7 +90,7 @@ Since all `wallet.rs` bindings are based on core principles provided by the `wal
 ### 1. Set up the Wallet Library
 First, you should install the components that are needed to use `wallet.rs` and the binding of your choice; it may vary a bit from language to language. In the case of the `NodeJs` binding, it is straightforward since it is distributed via the `npm` package manager. We also recommend you use `dotenv` for password management.
 
-You can read more about [backup and security in this guide](./guides/backup_security).
+You can read more about [backup and security in this guide](./backup_security).
 
 ```bash
 npm install @iota/wallet dotenv
@@ -119,7 +119,7 @@ One of the key principles behind the `stronghold`-based storage is that no one c
 
 :::note
 
-Keep the `stronghold` password and the `stronghold` database on separate devices. See the [backup and security guide](./guides/backup_security) for more information.
+Keep the `stronghold` password and the `stronghold` database on separate devices. See the [backup and security guide](./backup_security) for more information.
 
 :::
 
@@ -296,4 +296,4 @@ Default options are fine and are successful; however, additional options can be 
 
 The `Account.send()` function returns a `wallet message` that fully describes the given transaction. The `messageId` can be used later for checking a confirmation status. Individual messages related to the given account can be obtained via the `account.listMessages()` function.
 
-Please note that when sending tokens, a [dust protection](./guides/developer#dust-protection) mechanism should be considered. 
+Please note that when sending tokens, a [dust protection](./developer#dust-protection) mechanism should be considered. 

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -13,25 +13,25 @@ keywords:
 
 # IOTA Chrysalis Guides
 
-- [Developer Guide](https://wiki.iota.org/chrysalis-docs/guides/developer).
-- [Exchange Guide](https://wiki.iota.org/chrysalis-docs/guides/exchange).
-- [Token Migration Guide](https://wiki.iota.org/chrysalis-docs/guides/token_migration)
-- [Migration Mechanism](https://wiki.iota.org/chrysalis-docs/guides/migration_mechanism).
-- [Hub Migration Guide](https://wiki.iota.org/chrysalis-docs/guides/hub_migration).
-- [Backup and Security](https://wiki.iota.org/chrysalis-docs/guides/backup_security).
-- [Chrysalis Snapshot Validation](https://wiki.iota.org/chrysalis-docs/guides/snapshot_validation_bootstrapping).
+- [Developer Guide](./guides/developer).
+- [Exchange Guide](./guides/exchange).
+- [Token Migration Guide](./guides/token_migration)
+- [Migration Mechanism](./guides/migration_mechanism).
+- [Hub Migration Guide](./guides/hub_migration).
+- [Backup and Security](./guides/backup_security).
+- [Chrysalis Snapshot Validation](./guides/snapshot_validation_bootstrapping).
 
 
 ## Overall Changes from IOTA 1.0 to 1.5 (Chrysalis) in a Nutshell
 
-* The format of the address was changed, and it is now based on both the `derivation path` and `bech32` standards. For reference, you can read the [IOTA address anatomy](https://wiki.iota.org/chrysalis-docs/guides/developer#iota-15-address-anatomy) guide.
-* The concepts of `bundles` and `transactions` were replaced with `messages` and `payloads`. The `message` is a data structure that is actually being broadcast in the network and represents a node (vertex) in the Tangle graph. For reference, you can read both the [messages, payload, and transactions](https://wiki.iota.org/chrysalis-docs/guides/developer#messages-payloads-and-transactions) and [selected message payloads](https://wiki.iota.org/chrysalis-docs/guides/developer#selected-message-payloads) guides.
-* The IOTA network is based on a DAG (Directed Acyclic Graph) to store individual `messages` and related `transactions`. However, each `message` can newly reference up to 8 parent messages. For reference, you can read the [messages, payload, and transactions](https://wiki.iota.org/chrysalis-docs/guides/developer#messages-payloads-and-transactions) guide.
-* The signature scheme based on `WOTS` was replaced with the `Ed25519` signature scheme. For reference, you can read the [seed and addresses](https://wiki.iota.org/chrysalis-docs/guides/developer#seed-and-addresses) guide.
-* Due to the changed signature scheme, IOTA addresses are reusable without any negative security impact. Compared to IOTA 1.0, which was based on ternary, IOTA 1.5 is based on binary and is thus very efficient on all kinds of current hardware devices. In contrast to IOTA 1.0, IOTA 1.5 addresses are perfectly reusable; even if one spends funds from the given address, it can be used again. For reference, you can read the [address/key space](https://wiki.iota.org/chrysalis-docs/guides/developer#addresskey-space) guide.
-* Originally, IOTA 1.0 used an `account-based model` for tracking individual iota tokens. Chrysalis embraced the `Unspent Transaction Output` (also known as `UTXO`) model to track tokens and token holders. For reference, you can read the [Unspent Transaction Output](https://wiki.iota.org/chrysalis-docs/guides/developer#unspent-transaction-output-utxo) guide.
-* The approach to client libraries was completely reengineered from the ground up. There are new official client libraries that serve as `one-source-code-of-truth` to IOTA users and can be combined in a modular fashion based on particular use cases. All libraries provide a binding to other programming languages. For reference, you can read an overview of [client libraries](https://wiki.iota.org/chrysalis-docs/libraries/overview).
+* The format of the address was changed, and it is now based on both the `derivation path` and `bech32` standards. For reference, you can read the [IOTA address anatomy](./guides/developer#iota-15-address-anatomy) guide.
+* The concepts of `bundles` and `transactions` were replaced with `messages` and `payloads`. The `message` is a data structure that is actually being broadcast in the network and represents a node (vertex) in the Tangle graph. For reference, you can read both the [messages, payload, and transactions](./guides/developer#messages-payloads-and-transactions) and [selected message payloads](./guides/developer#selected-message-payloads) guides.
+* The IOTA network is based on a DAG (Directed Acyclic Graph) to store individual `messages` and related `transactions`. However, each `message` can newly reference up to 8 parent messages. For reference, you can read the [messages, payload, and transactions](./guides/developer#messages-payloads-and-transactions) guide.
+* The signature scheme based on `WOTS` was replaced with the `Ed25519` signature scheme. For reference, you can read the [seed and addresses](./guides/developer#seed-and-addresses) guide.
+* Due to the changed signature scheme, IOTA addresses are reusable without any negative security impact. Compared to IOTA 1.0, which was based on ternary, IOTA 1.5 is based on binary and is thus very efficient on all kinds of current hardware devices. In contrast to IOTA 1.0, IOTA 1.5 addresses are perfectly reusable; even if one spends funds from the given address, it can be used again. For reference, you can read the [address/key space](./guides/developer#addresskey-space) guide.
+* Originally, IOTA 1.0 used an `account-based model` for tracking individual iota tokens. Chrysalis embraced the `Unspent Transaction Output` (also known as `UTXO`) model to track tokens and token holders. For reference, you can read the [Unspent Transaction Output](./guides/developer#unspent-transaction-output-utxo) guide.
+* The approach to client libraries was completely reengineered from the ground up. There are new official client libraries that serve as `one-source-code-of-truth` to IOTA users and can be combined in a modular fashion based on particular use cases. All libraries provide a binding to other programming languages. For reference, you can read an overview of [client libraries](./libraries/overview).
 * Our official IOTA tools, such as wallet software, use the same libraries under the hood so any developer may work in the same environment as we do.
-* The official client libraries embraced an `Hierarchical Deterministic Wallets` approach which is fully `BIP44` compatible. For reference, you can read the [address/key space](https://wiki.iota.org/chrysalis-docs/guides/developer#addresskey-space) guide.
+* The official client libraries embraced an `Hierarchical Deterministic Wallets` approach which is fully `BIP44` compatible. For reference, you can read the [address/key space](./guides/developer#addresskey-space) guide.
 * There is a new official wallet software called Firefly. See [Firefly](https://firefly.iota.org/) and the Repo at: [Firefly Github](https://github.com/iotaledger/firefly)
 

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -13,25 +13,25 @@ keywords:
 
 # IOTA Chrysalis Guides
 
-- [Developer Guide](./guides/developer).
-- [Exchange Guide](./guides/exchange).
-- [Token Migration Guide](./guides/token_migration)
-- [Migration Mechanism](./guides/migration_mechanism).
-- [Hub Migration Guide](./guides/hub_migration).
-- [Backup and Security](./guides/backup_security).
-- [Chrysalis Snapshot Validation](./guides/snapshot_validation_bootstrapping).
+- [Developer Guide](./developer).
+- [Exchange Guide](./exchange).
+- [Token Migration Guide](./token_migration)
+- [Migration Mechanism](./migration_mechanism).
+- [Hub Migration Guide](./hub_migration).
+- [Backup and Security](./backup_security).
+- [Chrysalis Snapshot Validation](./snapshot_validation_bootstrapping).
 
 
 ## Overall Changes from IOTA 1.0 to 1.5 (Chrysalis) in a Nutshell
 
-* The format of the address was changed, and it is now based on both the `derivation path` and `bech32` standards. For reference, you can read the [IOTA address anatomy](./guides/developer#iota-15-address-anatomy) guide.
-* The concepts of `bundles` and `transactions` were replaced with `messages` and `payloads`. The `message` is a data structure that is actually being broadcast in the network and represents a node (vertex) in the Tangle graph. For reference, you can read both the [messages, payload, and transactions](./guides/developer#messages-payloads-and-transactions) and [selected message payloads](./guides/developer#selected-message-payloads) guides.
-* The IOTA network is based on a DAG (Directed Acyclic Graph) to store individual `messages` and related `transactions`. However, each `message` can newly reference up to 8 parent messages. For reference, you can read the [messages, payload, and transactions](./guides/developer#messages-payloads-and-transactions) guide.
-* The signature scheme based on `WOTS` was replaced with the `Ed25519` signature scheme. For reference, you can read the [seed and addresses](./guides/developer#seed-and-addresses) guide.
-* Due to the changed signature scheme, IOTA addresses are reusable without any negative security impact. Compared to IOTA 1.0, which was based on ternary, IOTA 1.5 is based on binary and is thus very efficient on all kinds of current hardware devices. In contrast to IOTA 1.0, IOTA 1.5 addresses are perfectly reusable; even if one spends funds from the given address, it can be used again. For reference, you can read the [address/key space](./guides/developer#addresskey-space) guide.
-* Originally, IOTA 1.0 used an `account-based model` for tracking individual iota tokens. Chrysalis embraced the `Unspent Transaction Output` (also known as `UTXO`) model to track tokens and token holders. For reference, you can read the [Unspent Transaction Output](./guides/developer#unspent-transaction-output-utxo) guide.
-* The approach to client libraries was completely reengineered from the ground up. There are new official client libraries that serve as `one-source-code-of-truth` to IOTA users and can be combined in a modular fashion based on particular use cases. All libraries provide a binding to other programming languages. For reference, you can read an overview of [client libraries](./libraries/overview).
+* The format of the address was changed, and it is now based on both the `derivation path` and `bech32` standards. For reference, you can read the [IOTA address anatomy](./developer#iota-15-address-anatomy) guide.
+* The concepts of `bundles` and `transactions` were replaced with `messages` and `payloads`. The `message` is a data structure that is actually being broadcast in the network and represents a node (vertex) in the Tangle graph. For reference, you can read both the [messages, payload, and transactions](./developer#messages-payloads-and-transactions) and [selected message payloads](./developer#selected-message-payloads) guides.
+* The IOTA network is based on a DAG (Directed Acyclic Graph) to store individual `messages` and related `transactions`. However, each `message` can newly reference up to 8 parent messages. For reference, you can read the [messages, payload, and transactions](./developer#messages-payloads-and-transactions) guide.
+* The signature scheme based on `WOTS` was replaced with the `Ed25519` signature scheme. For reference, you can read the [seed and addresses](./developer#seed-and-addresses) guide.
+* Due to the changed signature scheme, IOTA addresses are reusable without any negative security impact. Compared to IOTA 1.0, which was based on ternary, IOTA 1.5 is based on binary and is thus very efficient on all kinds of current hardware devices. In contrast to IOTA 1.0, IOTA 1.5 addresses are perfectly reusable; even if one spends funds from the given address, it can be used again. For reference, you can read the [address/key space](./developer#addresskey-space) guide.
+* Originally, IOTA 1.0 used an `account-based model` for tracking individual iota tokens. Chrysalis embraced the `Unspent Transaction Output` (also known as `UTXO`) model to track tokens and token holders. For reference, you can read the [Unspent Transaction Output](./developer#unspent-transaction-output-utxo) guide.
+* The approach to client libraries was completely reengineered from the ground up. There are new official client libraries that serve as `one-source-code-of-truth` to IOTA users and can be combined in a modular fashion based on particular use cases. All libraries provide a binding to other programming languages. For reference, you can read an overview of [client libraries](../libraries/overview).
 * Our official IOTA tools, such as wallet software, use the same libraries under the hood so any developer may work in the same environment as we do.
-* The official client libraries embraced an `Hierarchical Deterministic Wallets` approach which is fully `BIP44` compatible. For reference, you can read the [address/key space](./guides/developer#addresskey-space) guide.
+* The official client libraries embraced an `Hierarchical Deterministic Wallets` approach which is fully `BIP44` compatible. For reference, you can read the [address/key space](./developer#addresskey-space) guide.
 * There is a new official wallet software called Firefly. See [Firefly](https://firefly.iota.org/) and the Repo at: [Firefly Github](https://github.com/iotaledger/firefly)
 

--- a/docs/guides/token_migration.md
+++ b/docs/guides/token_migration.md
@@ -43,7 +43,7 @@ Firefly will initially only be available on desktop operating systems such as: m
 
 For further information on the migration process, see our [blog post](https://blog.iota.org/firefly-token-migration/).
 
-For a detailed explanation on how the migration process works technically, see the [migration-mechanism](https://wiki.iota.org/chrysalis-docs/guides/migration_mechanism) page.
+For a detailed explanation on how the migration process works technically, see the [migration-mechanism](./guides/migration_mechanism) page.
 
 ## Exchange Token Migration Guide
 
@@ -360,4 +360,4 @@ const selectInputsForUnspentAddresses = (inputs) => {
 };
 ```
 
-After the migration, only the 24-word mnemonic or the stronghold file gives you access to the funds, so make sure to back them up properly. It is impossible to get access to the funds with the old seed after the migration transaction. Please read our recommendations for [Backup and security](https://wiki.iota.org/chrysalis-docs/guides/backup_security).
+After the migration, only the 24-word mnemonic or the stronghold file gives you access to the funds, so make sure to back them up properly. It is impossible to get access to the funds with the old seed after the migration transaction. Please read our recommendations for [Backup and security](./guides/backup_security).

--- a/docs/guides/token_migration.md
+++ b/docs/guides/token_migration.md
@@ -43,7 +43,7 @@ Firefly will initially only be available on desktop operating systems such as: m
 
 For further information on the migration process, see our [blog post](https://blog.iota.org/firefly-token-migration/).
 
-For a detailed explanation on how the migration process works technically, see the [migration-mechanism](./guides/migration_mechanism) page.
+For a detailed explanation on how the migration process works technically, see the [migration-mechanism](./migration_mechanism) page.
 
 ## Exchange Token Migration Guide
 
@@ -360,4 +360,4 @@ const selectInputsForUnspentAddresses = (inputs) => {
 };
 ```
 
-After the migration, only the 24-word mnemonic or the stronghold file gives you access to the funds, so make sure to back them up properly. It is impossible to get access to the funds with the old seed after the migration transaction. Please read our recommendations for [Backup and security](./guides/backup_security).
+After the migration, only the 24-word mnemonic or the stronghold file gives you access to the funds, so make sure to back them up properly. It is impossible to get access to the funds with the old seed after the migration transaction. Please read our recommendations for [Backup and security](./backup_security).

--- a/docs/libraries/client.md
+++ b/docs/libraries/client.md
@@ -23,7 +23,7 @@ The official client library for interacting with the IOTA Tangle allows you to:
 
 However, if you want to process value transfers, you should use our stateful [wallet library](wallet.md) instead.
 
-[IOTA Client Library full documentation](https://wiki.iota.org/chrysalis-docs/libraries/client).
+[IOTA Client Library full documentation](./libraries/client).
 
 ## Rust
 

--- a/docs/libraries/client.md
+++ b/docs/libraries/client.md
@@ -23,7 +23,7 @@ The official client library for interacting with the IOTA Tangle allows you to:
 
 However, if you want to process value transfers, you should use our stateful [wallet library](wallet.md) instead.
 
-[IOTA Client Library full documentation](./libraries/client).
+[IOTA Client Library full documentation](https://wiki.iota.org/iota.rs/welcome).
 
 ## Rust
 

--- a/docs/tutorials/mainnet_hornet_node_k8s.md
+++ b/docs/tutorials/mainnet_hornet_node_k8s.md
@@ -1,6 +1,6 @@
 #  How to Run Iota Mainnet Hornet Nodes on a Kubernetes Environment
 
-In this tutorial, you will learn how to run [IOTA mainnet](https://wiki.iota.org/chrysalis-docs/mainnet) [Hornet](https://wiki.iota.org/hornet/welcome) nodes on a Kubernetes (K8s) environment. [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) is a portable, extensible, open-source platform for managing containerized workloads and services that facilitates both **declarative configuration** and automation. It has a large, rapidly growing ecosystem. K8s services, support, and tools are widely available on multiple cloud providers.
+In this tutorial, you will learn how to run [IOTA mainnet](./mainnet) [Hornet](https://wiki.iota.org/hornet/welcome) nodes on a Kubernetes (K8s) environment. [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) is a portable, extensible, open-source platform for managing containerized workloads and services that facilitates both **declarative configuration** and automation. It has a large, rapidly growing ecosystem. K8s services, support, and tools are widely available on multiple cloud providers.
 
 If you are not familiar with K8s we recommend you to start by [learning the K8s technology](https://kubernetes.io/docs/tutorials/kubernetes-basics/).
 

--- a/docs/tutorials/mainnet_hornet_node_k8s.md
+++ b/docs/tutorials/mainnet_hornet_node_k8s.md
@@ -1,6 +1,6 @@
 #  How to Run Iota Mainnet Hornet Nodes on a Kubernetes Environment
 
-In this tutorial, you will learn how to run [IOTA mainnet](./mainnet) [Hornet](https://wiki.iota.org/hornet/welcome) nodes on a Kubernetes (K8s) environment. [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) is a portable, extensible, open-source platform for managing containerized workloads and services that facilitates both **declarative configuration** and automation. It has a large, rapidly growing ecosystem. K8s services, support, and tools are widely available on multiple cloud providers.
+In this tutorial, you will learn how to run [IOTA mainnet](../mainnet) [Hornet](https://wiki.iota.org/hornet/welcome) nodes on a Kubernetes (K8s) environment. [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) is a portable, extensible, open-source platform for managing containerized workloads and services that facilitates both **declarative configuration** and automation. It has a large, rapidly growing ecosystem. K8s services, support, and tools are widely available on multiple cloud providers.
 
 If you are not familiar with K8s we recommend you to start by [learning the K8s technology](https://kubernetes.io/docs/tutorials/kubernetes-basics/).
 

--- a/docs/tutorials/one_click_private_tangle.md
+++ b/docs/tutorials/one_click_private_tangle.md
@@ -16,7 +16,7 @@ In this tutorial, you will learn how to use a set of Docker-based tools and pre-
 
 ## Background
 
-IOTA [mainnet](https://wiki.iota.org/chrysalis-docs/mainnet) and [devnet](https://wiki.iota.org/chrysalis-docs/devnet) are public IOTA Networks where you can develop your own applications. Due to scalability or data locality reasons, sometimes it is necessary to run your own *local* IOTA Tangle (aka Private Tangle). In the future, the (child) Tangle may also be *anchored* to the IOTA mainnet, through Data Sharding (a feature currently under research and development by the IOTA Foundation). To automate and simplify the deployment of a Chrysalis Tangle, some tools, publicly available in the [one-click-tangle](https://github.com/iotaledger/one-click-tangle) repository, have been developed. We have also integrated them for use in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/B095WQQTNG/) and, in the future, on other Cloud marketplaces.
+IOTA [mainnet](./mainnet) and [devnet](./devnet) are public IOTA Networks where you can develop your own applications. Due to scalability or data locality reasons, sometimes it is necessary to run your own *local* IOTA Tangle (aka Private Tangle). In the future, the (child) Tangle may also be *anchored* to the IOTA mainnet, through Data Sharding (a feature currently under research and development by the IOTA Foundation). To automate and simplify the deployment of a Chrysalis Tangle, some tools, publicly available in the [one-click-tangle](https://github.com/iotaledger/one-click-tangle) repository, have been developed. We have also integrated them for use in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/B095WQQTNG/) and, in the future, on other Cloud marketplaces.
 
 ## MVP Deployment Architecture
 
@@ -269,4 +269,4 @@ There could be limitations in the number of peers triggered by the maximum numbe
 
 ## Next Steps
 
-Try using one of the [client libraries](https://wiki.iota.org/chrysalis-docs/libraries/client) to send transactions to the nodes in your Tangle. 
+Try using one of the [client libraries](./libraries/client) to send transactions to the nodes in your Tangle. 

--- a/docs/tutorials/one_click_private_tangle.md
+++ b/docs/tutorials/one_click_private_tangle.md
@@ -16,7 +16,7 @@ In this tutorial, you will learn how to use a set of Docker-based tools and pre-
 
 ## Background
 
-IOTA [mainnet](./mainnet) and [devnet](./devnet) are public IOTA Networks where you can develop your own applications. Due to scalability or data locality reasons, sometimes it is necessary to run your own *local* IOTA Tangle (aka Private Tangle). In the future, the (child) Tangle may also be *anchored* to the IOTA mainnet, through Data Sharding (a feature currently under research and development by the IOTA Foundation). To automate and simplify the deployment of a Chrysalis Tangle, some tools, publicly available in the [one-click-tangle](https://github.com/iotaledger/one-click-tangle) repository, have been developed. We have also integrated them for use in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/B095WQQTNG/) and, in the future, on other Cloud marketplaces.
+IOTA [mainnet](../mainnet) and [devnet](../devnet) are public IOTA Networks where you can develop your own applications. Due to scalability or data locality reasons, sometimes it is necessary to run your own *local* IOTA Tangle (aka Private Tangle). In the future, the (child) Tangle may also be *anchored* to the IOTA mainnet, through Data Sharding (a feature currently under research and development by the IOTA Foundation). To automate and simplify the deployment of a Chrysalis Tangle, some tools, publicly available in the [one-click-tangle](https://github.com/iotaledger/one-click-tangle) repository, have been developed. We have also integrated them for use in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/B095WQQTNG/) and, in the future, on other Cloud marketplaces.
 
 ## MVP Deployment Architecture
 
@@ -269,4 +269,4 @@ There could be limitations in the number of peers triggered by the maximum numbe
 
 ## Next Steps
 
-Try using one of the [client libraries](./libraries/client) to send transactions to the nodes in your Tangle. 
+Try using one of the [client libraries](../libraries/client) to send transactions to the nodes in your Tangle. 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ module.exports = {
                 path: path.resolve(__dirname, 'docs'),
                 routeBasePath: 'introduction',
                 sidebarPath: path.resolve(__dirname, 'sidebars.js'),
-                editUrl: 'https://github.com/iotaledger/chrysalis-docs/edit/main',
+                editUrl: 'https://github.com/iotaledger/introduction-docs/edit/main',
                 remarkPlugins: [require('remark-code-import'), require('remark-import-partial'), require('remark-remove-comments')],
             }
         ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,9 +5,9 @@ module.exports = {
         [
             '@docusaurus/plugin-content-docs',
             {
-                id: 'chrysalis-docs',
+                id: 'introduction-docs',
                 path: path.resolve(__dirname, 'docs'),
-                routeBasePath: 'chrysalis-docs',
+                routeBasePath: 'introduction',
                 sidebarPath: path.resolve(__dirname, 'sidebars.js'),
                 editUrl: 'https://github.com/iotaledger/chrysalis-docs/edit/main',
                 remarkPlugins: [require('remark-code-import'), require('remark-import-partial'), require('remark-remove-comments')],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chrysalis-docs",
+  "name": "introduction-docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3913,17 +3913,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"introduction-docs@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "introduction-docs@workspace:."
-  dependencies:
-    "@iota-community/iota-wiki-cli": "iota-community/iota-wiki-cli#v2"
-    remark-code-import: ^0.3.0
-    remark-import-partial: ^0.0.2
-    remark-remove-comments: ^0.2.0
-  languageName: unknown
-  linkType: soft
-
 "ci-info@npm:^2.0.0":
   version: 2.0.0
   resolution: "ci-info@npm:2.0.0"
@@ -6613,6 +6602,17 @@ __metadata:
   checksum: 2e5f51268b5941e4a17e4ef0575bc91ed0ab5f8515e3cf77486f7c14d13f3010df9c0959f37063dcc96e78d12dc6b0bb1b9e111cdfe69771f4656d2993d36155
   languageName: node
   linkType: hard
+
+"introduction-docs@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "introduction-docs@workspace:."
+  dependencies:
+    "@iota-community/iota-wiki-cli": "iota-community/iota-wiki-cli#v2"
+    remark-code-import: ^0.3.0
+    remark-import-partial: ^0.0.2
+    remark-remove-comments: ^0.2.0
+  languageName: unknown
+  linkType: soft
 
 "invariant@npm:^2.2.4":
   version: 2.2.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -3913,9 +3913,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrysalis-docs@workspace:.":
+"introduction-docs@workspace:.":
   version: 0.0.0-use.local
-  resolution: "chrysalis-docs@workspace:."
+  resolution: "introduction-docs@workspace:."
   dependencies:
     "@iota-community/iota-wiki-cli": "iota-community/iota-wiki-cli#v2"
     remark-code-import: ^0.3.0


### PR DESCRIPTION
# Description of Change

As this docs in the future house introduction docs for all kinds of updates I renamed it.

Can/Should we already rename the repo too?
Then I need to make 2 more changes

## Type of Change

- Documentation Enhancement

## How the Change Has Been Tested

Not tested. Let's wait for the action to do that :trollface: 

## Change Checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested the docs locally
